### PR TITLE
[FE8] Add NOP raw

### DIFF
--- a/EXPERIMENTAL-CHANGELOG.md
+++ b/EXPERIMENTAL-CHANGELOG.md
@@ -16,3 +16,4 @@ This is a list of things that the experimental branch has changed from the offic
   - `SETVAL`, `SLOTS_LEFTSHIFT` and `SLOTS_RIGHTSHIFT` are deprecated and now require `BACKWARDS_COMPATIBILITY` (Stan).
 - Fixed `TurnEventNPC` macros for FE8 (Sme).
 - Fixed typo in Seize eid definition (kept `SiezeID` for compatibility) (Sme).
+- Add FE8 `NOP` which does nothing, for completeness (Stan).

--- a/Language Raws/Miscellaneous/Misc.txt
+++ b/Language Raws/Miscellaneous/Misc.txt
@@ -1,3 +1,7 @@
+
+## Does nothing
+NOP, 0x0020, 4, -game:FE8
+
 #Generates a random number between 0 and the parameter
 #Result is stored to memory slot 0xC
 RANDOMNUMBER, 0x0420, 4, -game:FE8 -indexMode:8

--- a/Language Raws/Miscellaneous/Misc.txt
+++ b/Language Raws/Miscellaneous/Misc.txt
@@ -1,6 +1,6 @@
 
 ## Does nothing
-NOP, 0x0020, 4, -game:FE8
+NOP, 0x0020, 4, -game:FE8 -indexMode:8
 
 #Generates a random number between 0 and the parameter
 #Result is stored to memory slot 0xC


### PR DESCRIPTION
Which does nothing. This is solely for completeness of the event library, as it is handled by the vanilla game.