### PR TITLE
Macro & raw error corrections & additions

### DIFF
--- a/EA Standard Library/Unit Helpers.txt
+++ b/EA Standard Library/Unit Helpers.txt
@@ -101,8 +101,8 @@
 #endif
 
 #ifdef _FE8_
-#define WarpIn(Char,X,Y)		"_SETVAL 2 Char; _WARP -1 -3 [X,Y]; CALL $9EE4F8"
-#define WarpOut(Char,X,Y)		"_SETVAL 2 Char; _WARP -1 -3 [X,Y]; CALL $9EE4F8"
+#define WarpIn(Char,X,Y)		"SVAL 2 Char; _WARP -1 -3 [X,Y]; CALL $9EE4F8"
+#define WarpOut(Char,X,Y)		"SVAL 2 Char; _WARP -1 -3 [X,Y]; CALL $9EE4F8"
 #endif
 
 
@@ -136,27 +136,27 @@
 #endif
 
 #ifdef _FE8_
-#define StartBattle                           "_SETVAL 0xD 0x0"
-#define NormalDamage(combatantNumber,damage)  "_SETVAL 1 combatantNumber+damage*0x100;            SAVETOQUEUE"
-#define CriticalHit(combatantNumber,damage)   "_SETVAL 1 combatantNumber+damage*0x100+0x00010000; SAVETOQUEUE"
-#define MissedAttack(combatantNumber,damage)  "_SETVAL 1 combatantNumber+damage*0x100+0x00020000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x00040000; SAVETOQUEUE"
-#define Silencer(combatantNumber,damage)      "_SETVAL 1 combatantNumber+damage*0x100+0x00080000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x00100000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x00200000; SAVETOQUEUE"
-#define SureShot(combatantNumber,damage)      "_SETVAL 1 combatantNumber+damage*0x100+0x00400000; SAVETOQUEUE"
-#define Poison(combatantNumber,damage)        "_SETVAL 1 combatantNumber+damage*0x100+0x00400000; SAVETOQUEUE"
-#define DevilReversal(combatantNumber,damage) "_SETVAL 1 combatantNumber+damage*0x100+0x00800000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x01000000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x02000000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x04000000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x08000000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x10000000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x20000000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x40000000; SAVETOQUEUE"
-//#define Unknown(combatantNumber,damage)     "_SETVAL 1 combatantNumber+damage*0x100+0x80000000; SAVETOQUEUE"
-#define Pierce(combatantNumber,damage)        "_SETVAL 1 combatantNumber+damage*0x100+0xC0000000; SAVETOQUEUE"
-#define EndAttack                             "_SETVAL 1 0xFFFFFFFF;                              SAVETOQUEUE"
+#define StartBattle                           "SVAL 0xD 0x0"
+#define NormalDamage(combatantNumber,damage)  "SVAL 1 combatantNumber+damage*0x100;            SAVETOQUEUE"
+#define CriticalHit(combatantNumber,damage)   "SVAL 1 combatantNumber+damage*0x100+0x00010000; SAVETOQUEUE"
+#define MissedAttack(combatantNumber,damage)  "SVAL 1 combatantNumber+damage*0x100+0x00020000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x00040000; SAVETOQUEUE"
+#define Silencer(combatantNumber,damage)      "SVAL 1 combatantNumber+damage*0x100+0x00080000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x00100000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x00200000; SAVETOQUEUE"
+#define SureShot(combatantNumber,damage)      "SVAL 1 combatantNumber+damage*0x100+0x00400000; SAVETOQUEUE"
+#define Poison(combatantNumber,damage)        "SVAL 1 combatantNumber+damage*0x100+0x00400000; SAVETOQUEUE"
+#define DevilReversal(combatantNumber,damage) "SVAL 1 combatantNumber+damage*0x100+0x00800000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x01000000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x02000000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x04000000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x08000000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x10000000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x20000000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x40000000; SAVETOQUEUE"
+//#define Unknown(combatantNumber,damage)     "SVAL 1 combatantNumber+damage*0x100+0x80000000; SAVETOQUEUE"
+#define Pierce(combatantNumber,damage)        "SVAL 1 combatantNumber+damage*0x100+0xC0000000; SAVETOQUEUE"
+#define EndAttack                             "SVAL 1 0xFFFFFFFF;                              SAVETOQUEUE"
 #endif
 
 //Battle data helpers

--- a/Language Raws/Convos/Text.txt
+++ b/Language Raws/Convos/Text.txt
@@ -164,6 +164,9 @@ BROWNBOXTEXT, 0x3A41, 8, -game:FE8 -indexMode:8
 ##Starts the text showing.
 TEXTSTART, 0x1A20, 4, -game:FE8 -indexMode:8
 
+##Starts cg text.
+CGTEXTSTART, 0x1A22, 4, -game:FE8 -indexMode:8
+
 #The yellowish text box used for tutorials
 #Center with SETVAL 0xB 0xFFFFFFFF
 TUTORIALTEXTBOXSTART, 0x1A23, 4, -game:FE8 -indexMode:8

--- a/Language Raws/FE8StanAliases.txt
+++ b/Language Raws/FE8StanAliases.txt
@@ -471,8 +471,8 @@ WARPIN_SB, 0x4121, 4, -game:FE8 -indexMode:8
 ENDWARP, 0x412F, 4, -game:FE8 -indexMode:8
 
 EARTHQUAKE, 0x4220, 4, -game:FE8 -indexMode:8
-	ShakeDirection, 1, 1, -preferredBase:10
-	PlaySoundBool,  1, 1, -preferredBase:10
+	ShakeDirection, 2, 1, -preferredBase:10
+	PlaySoundBool,  3, 1, -preferredBase:10
 
 ## Displays summoning animation on the given character
 SUMMONUNIT, 0x4320, 4, -game:FE8 -indexMode:8

--- a/Language Raws/Main codes/Character based events.txt
+++ b/Language Raws/Main codes/Character based events.txt
@@ -64,7 +64,7 @@ CHAR, 0, 4, -priority:main -language:FE8:FE7:FE6 -end -indexMode:8 -noDisassembl
 
 ##Like normal CHAR, except the ASM routine must return true for
 ##the Talk option to appear.
-CHARASM, 0x4, 16, -game:FE7 -indexMode:8 -priority:main
+CHARASM, 0x4, 16, -game:FE7:FE8 -indexMode:8 -priority:main
 ##Event ID of the event. After the event ID has been used,
 ##this event can't be invoked. Leaving this 0 will allow event to
 ##whenever otherwise possible.
@@ -81,7 +81,7 @@ CHARASM, 0x4, 16, -game:FE7 -indexMode:8 -priority:main
 ##Thumb routines must also have 1 added to their offset.
 	ASM pointer, 12, 4, -pointer:ASM
 
-CHARASM, 0x4, 16, -game:FE7 -indexMode:8 -priority:main
+CHARASM, 0x4, 16, -game:FE7:FE8 -indexMode:8 -priority:main
 	Event ID, 2, 2
 	Event pointer, 4, 4, -pointer:none
 ##Character to start the event.
@@ -90,7 +90,7 @@ CHARASM, 0x4, 16, -game:FE7 -indexMode:8 -priority:main
 	Character 2, 9, 1
 	ASM pointer, 12, 4, -pointer:ASM
 
-CHARASM, 0, 4, -priority:main -language:FE7 -end -indexMode:8 -noDisassembly
+CHARASM, 0, 4, -priority:main -language:FE7:FE8 -end -indexMode:8 -noDisassembly
 	0, 0, 4, -fixed
 
 


### PR DESCRIPTION
Changes instances of `_SETVAL` to `SVAL` so the macros do not throw errors in `EA Standard Library/Unit Helpers.txt`.
Argument offsets in the `EARTHQUAKE` raw were incorrect and are now fixed.
Adds raw CGTEXTSTART for 0x1A22.
Denotes that `CHARASM` is valid in FE8 too, not just FE7.

I've gone through the entire list of event things now so this should be all of the issues I've found working with this stdlib corrected, though there are likely still more instances of macros that error.