### PR TITLE
Change `-language` to `-game`

### DIFF
--- a/Language Raws/Common/Event.txt
+++ b/Language Raws/Common/Event.txt
@@ -1,12 +1,12 @@
 
 ##Event that happens after another event happens.
-AFEV, 1, 12, -language:FE8:FE7:FE7J:FE6 -priority:main -indexMode:8
+AFEV, 1, 12, -game:FE8:FE7:FE7J:FE6 -priority:main -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Event ID to follow, 8, 2
 
 ##Turn based events that happen at a specific part of one or several turns.
-TURN, 2, 96, -priority:main -language:FE6:FE8
+TURN, 2, 96, -priority:main -game:FE6:FE8
 	ID, 16, 16, 
 	Event Pointer, 32, 32, -pointer 
 	Turns, 64, 16, -coordinates:2 -preferredBase:10
@@ -19,14 +19,14 @@ TURN_HM, 3, 96, -game:FE6 -priority:main
 	Turns, 64, 16, -coordinates:2 -preferredBase:10
 	TurnMoment, 84, 4
 
-TURN, 2, 128, -priority:main -language:FE7:FE7J
+TURN, 2, 128, -priority:main -game:FE7:FE7J
 	ID, 16, 16, 
 	Event Pointer, 32, 32, -pointer 
 	Turns, 64, 16, -coordinates:2 -preferredBase:10
 	TurnMoment, 84, 4
 	Extra, 96, 32
 
-TURN, 2, 128, -priority:main -language:FE7:FE7J
+TURN, 2, 128, -priority:main -game:FE7:FE7J
 	ID, 16, 16, 
 	Event Pointer, 32, 32, -pointer 
 	Turns, 64, 16, -coordinates:2 -preferredBase:10
@@ -38,18 +38,18 @@ TURN, 2, 128, -priority:main -language:FE7:FE7J
 
 ##Event that happens when two characters land next to each
 ##other and talk convo is selected.
-CHAR, 4, 12, -language:FE6 -priority:main -indexMode:8
+CHAR, 4, 12, -game:FE6 -priority:main -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Characters, 8, 2, -coordinates:2
 
-CHAR, 3, 16, -language:FE7:FE7J:FE8 -priority:main -indexMode:8
+CHAR, 3, 16, -game:FE7:FE7J:FE8 -priority:main -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Characters, 8, 2, -coordinates:2
 	Extra, 12, 4
 
-CHAR, 3, 16, -language:FE7:FE7J:FE8 -priority:main -indexMode:8
+CHAR, 3, 16, -game:FE7:FE7J:FE8 -priority:main -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Characters, 8, 2, -coordinates:2
@@ -58,14 +58,14 @@ CHAR, 3, 16, -language:FE7:FE7J:FE8 -priority:main -indexMode:8
 	Extra3, 14, 1
 	Extra4, 15, 1
 
-CHAR, 3, 16, -language:FE7:FE7J:FE8 -priority:main -indexMode:8
+CHAR, 3, 16, -game:FE7:FE7J:FE8 -priority:main -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Character 1, 8, 1
 	Character 2, 9, 1
 	Extra, 12, 4
 
-CHAR, 3, 16, -language:FE7:FE7J:FE8 -priority:main -indexMode:8
+CHAR, 3, 16, -game:FE7:FE7J:FE8 -priority:main -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Character 2, 8, 1
@@ -94,19 +94,19 @@ CHARASM, 4, 16, -game:FE7:FE7J:FE8 -indexMode:8 -priority:main
 ##specified position and player selects the correct command from the menu.
 ##Leaving Event pointer out and having ID as 3 causes the event to automatically
 ##call the ending scene of the chapter.
-LOCA, 5, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
+LOCA, 5, 12, -priority:main -game:FE8:FE7:FE7J:FE6 -indexMode:8
 	ID, 2, 2
 	1, 4, 4, -fixed
 	Position, 8, 2, -coordinates:2 -preferredBase:10
 	Command, 10, 2
 
-LOCA, 5, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
+LOCA, 5, 12, -priority:main -game:FE8:FE7:FE7J:FE6 -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Position, 8, 2, -coordinates:2 -preferredBase:10
 	Command, 10, 2
 
-CHESRANDOM, 5, 12, -priority:main -language:FE8 -indexMode:8
+CHESRANDOM, 5, 12, -priority:main -game:FE8 -indexMode:8
 	ID, 2, 2
 	Item List Pointer, 4, 4
 	Position, 8, 2, -coordinates:2 -preferredBase:10
@@ -114,14 +114,14 @@ CHESRANDOM, 5, 12, -priority:main -language:FE8 -indexMode:8
 
 ##The location based event used for visiting villages.
 ##A nearby map change happens automatically after this event.
-VILL, 6, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
+VILL, 6, 12, -priority:main -game:FE8:FE7:FE7J:FE6 -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Position, 8, 2, -coordinates:2 -preferredBase:10
 	Command, 10, 2
 
 ##Location based event that gives items or money and causes a map change.
-CHES, 7, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
+CHES, 7, 12, -priority:main -game:FE8:FE7:FE7J:FE6 -indexMode:8
 	ID, 2, 2
 	Chest data, 4, 4
 	Position, 8, 2, -coordinates:2 -preferredBase:10
@@ -130,27 +130,27 @@ CHES, 7, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
 ##Location based event triggered by unit being placed near and choosing
 ##the right command. Causes automatic map change if no Event pointer is 
 ##specified. 
-DOOR, 8, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
+DOOR, 8, 12, -priority:main -game:FE8:FE7:FE7J:FE6 -indexMode:8
 	ID, 2, 2
 	1, 4, 4, -fixed
 	Position, 8, 2, -coordinates:2 -preferredBase:10
 	Command, 10, 2
 
-DOOR, 8, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
+DOOR, 8, 12, -priority:main -game:FE8:FE7:FE7J:FE6 -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Position, 8, 2, -coordinates:2 -preferredBase:10
 	Command, 10, 2
 
 ##Location based event that takes the player to a shop to buy items.
-SHOP, 10, 12, -priority:main -language:FE8:FE7:FE7J:FE6 -indexMode:8
+SHOP, 10, 12, -priority:main -game:FE8:FE7:FE7J:FE6 -indexMode:8
 	ID, 2, 2
 	Shop List Pointer, 4, 4, -pointer:shopList
 	Position, 8, 2, -coordinates:2 -preferredBase:10
 	Command, 10, 2
 
 ##Event that happens when a unit lands on specific tiles.
-AREA, 11, 12, -language:FE8:FE7:FE7J:FE6 -priority:main -indexMode:8
+AREA, 11, 12, -game:FE8:FE7:FE7J:FE6 -priority:main -indexMode:8
 	ID, 2, 2
 	Event Pointer, 4, 4, -pointer
 	Corner 1, 8, 2, -coordinates:2 -preferredBase:10
@@ -167,37 +167,37 @@ ASME, 14, 12, -game:FE7:FE7J:FE8 -priority:main -indexMode:8
 	Pointer to event, 4, 4, -pointer
 	ASM Pointer, 8, 4, -pointer
 
-EVENT_UNKNOWN_15, 15, 16, -priority:main -language:FE7:FE7J:FE8 -indexMode:8
+EVENT_UNKNOWN_15, 15, 16, -priority:main -game:FE7:FE7J:FE8 -indexMode:8
 	ID, 2, 2 
 	Event Pointer, 4, 4, -pointer:coordList
 	Event Pointer2, 8, 4, -pointer
 	id2, 12, 4
 	
-EVENT_UNKNOWN_16, 16, 16, -priority:main -language:FE7:FE7J:FE8 -indexMode:8
+EVENT_UNKNOWN_16, 16, 16, -priority:main -game:FE7:FE7J:FE8 -indexMode:8
 	ID, 2, 2 
 	Event Pointer, 4, 4, -pointer:coordList
 	Event Pointer2, 8, 4, -pointer
 	id2, 12, 4
 
 ## End of main code list.
-END_MAIN, 0, 4, -priority:main -language:FE6:FE8:FE7:FE7J -end -indexMode:8
+END_MAIN, 0, 4, -priority:main -game:FE6:FE8:FE7:FE7J -end -indexMode:8
 
-AREA, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+AREA, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-AFEV, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+AFEV, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-CHAR, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+CHAR, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-CHARASM, 0, 4, -priority:main -language:FE7:FE7J:FE8 -end -indexMode:8 -noDisassembly
+CHARASM, 0, 4, -priority:main -game:FE7:FE7J:FE8 -end -indexMode:8 -noDisassembly
 
-LOCA, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+LOCA, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-VILL, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+VILL, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-SHOP, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+SHOP, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-CHES, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+CHES, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-DOOR, 0, 4, -priority:main -language:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
+DOOR, 0, 4, -priority:main -game:FE8:FE7:FE7J:FE6 -end -indexMode:8 -noDisassembly
 
-TURN, 0, 4, -priority:main -language:FE6:FE7:FE7J:FE8 -end -indexMode:8 -noDisassembly
+TURN, 0, 4, -priority:main -game:FE6:FE7:FE7J:FE8 -end -indexMode:8 -noDisassembly

--- a/Language Raws/Common/Misc.txt
+++ b/Language Raws/Common/Misc.txt
@@ -52,7 +52,7 @@ BLDT, 0, 32, -game:FE6:FE7:FE7J -priority:battleData -indexMode:1
 BLDT, 0, 4, -game:FE6:FE7:FE7J -indexMode:8 -priority:battleData -end
 	0x800000, 0, 4, -fixed
 
-COORDS, 0, 4, -priority:coordList -language:FE7:FE7J -indexMode:8
+COORDS, 0, 4, -priority:coordList -game:FE7:FE7J -indexMode:8
 	Position, 0, 2, -coordinates:2 -preferredBase:10
 
-ENDCOORDS, 0xFF, 4, -priority:coordList -language:FE7:FE7J -indexMode:8 -end
+ENDCOORDS, 0xFF, 4, -priority:coordList -game:FE7:FE7J -indexMode:8 -end

--- a/Language Raws/Common/Trap.txt
+++ b/Language Raws/Common/Trap.txt
@@ -1,20 +1,20 @@
 
-ENDTRAP, 0, 1, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -end -indexMode:8 -offsetMod:1
+ENDTRAP, 0, 1, -game:FE7:FE7J:FE8 -unsafe -priority:ballista -end -indexMode:8 -offsetMod:1
 
-BLST, 0, 6, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
+BLST, 0, 6, -game:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
 	1, 0, 1, -fixed 
 	Position, 1, 2, -coordinates:2 -preferredBase:10
 	Type, 3, 1
 
 ##Fire trap
-FIRE, 0, 6, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
+FIRE, 0, 6, -game:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
 	4, 0, 1, -fixed 
 	Position, 1, 2, -coordinates:2 -preferredBase:10
 	TimerStart, 4, 1
 	TimerRepeat, 5, 1
 
 ##Gas trap
-GAST, 0, 6, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
+GAST, 0, 6, -game:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
 	5, 0, 1, -fixed 
 	Position, 1, 2, -coordinates:2 -preferredBase:10
 	Direction, 3, 1
@@ -22,24 +22,24 @@ GAST, 0, 6, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offs
 	TimerRepeat, 5, 1
 
 ##Vertical arrow
-ARROW, 0, 6, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
+ARROW, 0, 6, -game:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
 	7, 0, 1, -fixed 
 	X coordinate, 1, 1, -coordinates:2 -preferredBase:10
 	TimerStart, 4, 1
 	TimerRepeat, 5, 1
 
 ##Instant fire
-FIRE2, 0, 6, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
+FIRE2, 0, 6, -game:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
 	8, 0, 1, -fixed 
 	Position, 1, 2, -coordinates:2 -preferredBase:10
 	
 ##Mine
-MINE, 0, 6, -language:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
+MINE, 0, 6, -game:FE7:FE7J:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
 	11, 0, 1, -fixed 
 	Position, 1, 2, -coordinates:2 -preferredBase:10
 
 ##Gorgon egg
-EGG, 0, 6, -language:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
+EGG, 0, 6, -game:FE8 -unsafe -priority:ballista -indexMode:8 -offsetMod:1
 	12, 0, 1, -fixed 
 	Position, 1, 2, -coordinates:2 -preferredBase:10
 	StartHatching, 3, 1

--- a/Language Raws/FE6/Scene-Flow.txt
+++ b/Language Raws/FE6/Scene-Flow.txt
@@ -3,7 +3,7 @@
 ENDA, 6, 8, -game:FE6 -end -indexMode:8
 
 ##Code that calls ASM routine in events.
-ASMC, 0x17, 8, -language:FE6 -repeatable -indexMode:8
+ASMC, 0x17, 8, -game:FE6 -repeatable -indexMode:8
 	Offset, 4, 4, -pointer:ASM
 
 ##Labels (target for conditional branches)

--- a/Language Raws/FE7/Scene-Flow.txt
+++ b/Language Raws/FE7/Scene-Flow.txt
@@ -5,7 +5,7 @@ ENDA, 0x0A, 8, -game:FE7 -end -indexMode:8
 ## preparations screen.
 ENDB, 0x0B, 8, -game:FE7 -end -indexMode:8
 
-ASMC, 0x3E, 8, -language:FE7 -repeatable -indexMode:8
+ASMC, 0x3E, 8, -game:FE7 -repeatable -indexMode:8
 	Offset, 4, 4, -pointer:ASM
 
 LABEL, 0x44, 8, -game:FE7 -indexMode:8

--- a/Language Raws/FE7J/Scene-Flow.txt
+++ b/Language Raws/FE7J/Scene-Flow.txt
@@ -1,6 +1,6 @@
 ENDA,0xa, 8, -game:FE7J -end -indexMode:8
 ENDB,0xb, 8, -game:FE7J -end -indexMode:8
-ASMC,0x3c, 8, -language:FE7J -repeatable -indexMode:8
+ASMC,0x3c, 8, -game:FE7J -repeatable -indexMode:8
 	Offset, 4, 4, -pointer:ASM
 LABEL,0x42, 8, -game:FE7J -indexMode:8
 	Conditional ID, 4, 2

--- a/Language Raws/FE8/Scene-Flow.txt
+++ b/Language Raws/FE8/Scene-Flow.txt
@@ -68,7 +68,7 @@ BLT, 0x0C45, 8, -game:FE8 -indexMode:8
 	SlotRight, 6, 2
 
 ## Calls native/ASM function (arg r0 = event engine proc)
-ASMC, 0x0D40, 8, -language:FE8 -repeatable -indexMode:8
+ASMC, 0x0D40, 8, -game:FE8 -repeatable -indexMode:8
 	Offset, 4, 4, -pointer:ASM
 
 ## Return to title screen
@@ -102,7 +102,7 @@ ENDA, 0x0120, 4, -game:FE8 -end -indexMode:8
 ENDB, 0x0121, 4, -game:FE8 -end -indexMode:8
 
 ## Strictly the same as ASMC
-ASMC2, 0x0D41, 8, -language:FE8 -repeatable -indexMode:8
+ASMC2, 0x0D41, 8, -game:FE8 -repeatable -indexMode:8
 	Offset, 4, 4, -pointer:ASM
 
 ## Return to title screen

--- a/Language Raws/FE8/Scene-Memory.txt
+++ b/Language Raws/FE8/Scene-Memory.txt
@@ -155,11 +155,11 @@ COUNTER_SET, 0x0F21, 4, -game:FE8 -indexMode:8
 	Value, 3, 1
 
 ## Increments value of given counter (max 15, won't overflow)
-COUNTER_INC, 0x0F22, 4, -language:FE8 -indexMode:8
+COUNTER_INC, 0x0F22, 4, -game:FE8 -indexMode:8
 	Id, 2, 1
 
 ## Decrements value of given counter (min 0, won't underflow)
-COUNTER_DEC, 0x0F23, 4, -language:FE8 -indexMode:8
+COUNTER_DEC, 0x0F23, 4, -game:FE8 -indexMode:8
 	Id, 2, 1
 
 # ======================


### PR DESCRIPTION
Though there's not supposed to be anything wrong with using `-language`, ColorzCore does not recognize it and as such treats every raw that uses it instead of `-game` as being valid regardless of the game setting. This most commonly breaks ASMCs when the first ASMC raw encountered is the FE6 one. Only a handful of raws used `-language`, so switching them to `-game` also establishes unified formatting.